### PR TITLE
Add Get Historical BEP-20 Token TotalSupply by ContractAddress & Bloc…

### DIFF
--- a/src/BscScan.NetCore/Constants/Constants.cs
+++ b/src/BscScan.NetCore/Constants/Constants.cs
@@ -85,6 +85,7 @@ internal static class TokenModuleAction
     public const string TOKEN_C_SUPPLY = "tokenCsupply";
     public const string TOKEN_BALANCE = "tokenbalance";
     public const string TOKEN_HOLDER_LIST = "tokenholderlist";
+    public const string TOKEN_SUPPLY_HISTORY = "tokensupplyhistory";
 }
 
 /// <summary>

--- a/src/BscScan.NetCore/Contracts/IBscScanTokensService.cs
+++ b/src/BscScan.NetCore/Contracts/IBscScanTokensService.cs
@@ -36,5 +36,14 @@ namespace BscScan.NetCore.Contracts
         /// <param name="request">TokenHolderListRequest</param>
         /// <returns></returns>
         Task<TokenHolderList?> GetTokenHolderListByContractAddress(TokenHolderListRequest request);
+
+
+        /// <summary>
+        /// Get Historical BEP-20 Token TotalSupply by ContractAddress and BlockNo  🅰🅿🅸  🅿🆁🅾
+        /// </summary>
+        /// <param name="contractAddress">the contract address of the BEP-20 token</param>
+        /// <param name="blockNo">the integer block number to check total supply for eg. 4000000</param>
+        /// <returns>Returns the historical amount of a BEP-20 token in circulation at a certain block height.</returns>
+        Task<HistoricalBep20TokenTotalSupply?> GetHistoricalBep20TokenTotalSupplyByContractAddressAndBlockNo(string contractAddress, int blockNo);
     }
 }

--- a/src/BscScan.NetCore/Models/Response/Tokens/HistoricalBep20TokenTotalSupply.cs
+++ b/src/BscScan.NetCore/Models/Response/Tokens/HistoricalBep20TokenTotalSupply.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BscScan.NetCore.Models.Response.Tokens
+{
+    /// <summary>
+    /// HistoricalBep20TokenTotalSupply
+    /// </summary>
+    public class HistoricalBep20TokenTotalSupply : BaseResponse
+    {
+        /// <summary>
+        /// result
+        /// </summary>
+        [JsonPropertyName("result")]
+        public string? Result { get; set; }
+    }
+}

--- a/src/BscScan.NetCore/Services/BscScanTokensService.cs
+++ b/src/BscScan.NetCore/Services/BscScanTokensService.cs
@@ -81,5 +81,22 @@ namespace BscScan.NetCore.Services
             var result = await JsonSerializer.DeserializeAsync<TokenHolderList>(responseStream);
             return result;
         }
+
+        /// <inheritdoc />
+        public async Task<HistoricalBep20TokenTotalSupply?> GetHistoricalBep20TokenTotalSupplyByContractAddressAndBlockNo(string contractAddress, int blockNo)
+        {
+            var queryParameters = $"{_bscScanModuleStat}".AddAction(TokenModuleAction.TOKEN_SUPPLY_HISTORY)
+                .AddQuery(BscQueryParam.ContractAddress.AppendValue(contractAddress))
+                .AddQuery(BscQueryParam.BlockNo.AppendValue(blockNo))
+                .AddQuery(BscQueryParam.Tag.AppendValue(Tag.Latest.ToString().ToLower()));
+
+            using var response = await BscScanHttpClient.GetAsync($"{queryParameters}")
+                .ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+            await using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var result = await JsonSerializer.DeserializeAsync<HistoricalBep20TokenTotalSupply>(responseStream);
+            return result;
+        }
     }
 }


### PR DESCRIPTION
…kNo (PRO)

Returns the historical amount of a BEP-20 token in circulation at a certain block height.