### PR TITLE
Add Get BNB Smart Chain Daily Total Gas Used

### DIFF
--- a/src/BscScan.NetCore/Constants/Constants.cs
+++ b/src/BscScan.NetCore/Constants/Constants.cs
@@ -105,6 +105,7 @@ internal static class GasTrackerModuleAction
 {
     public const string GAS_ORACLE = "gasoracle";
     public const string DAILY_AVG_GAS_LIMIT = "dailyavggaslimit";
+    public const string DAILY_GAS_USED = "dailygasused";
 }
 
 /// <summary>

--- a/src/BscScan.NetCore/Contracts/IBscScanGasTrackerService.cs
+++ b/src/BscScan.NetCore/Contracts/IBscScanGasTrackerService.cs
@@ -20,4 +20,11 @@ public interface IBscScanGasTrackerService
     /// <param name="request">DailyAverageGasLimitRequest</param>
     /// <returns>Returns the historical daily average gas limit of the BNB Smart Chain network.</returns>
     Task<DailyAverageGasLimit?> GetDailyAverageGasLimit(DailyAverageGasLimitRequest request);
+
+    /// <summary>
+    /// Get BNB Smart Chain Daily Total Gas Used 🅰🅿🅸  🅿🆁🅾
+    /// </summary>
+    /// <param name="request">BnbSmartChainDailyTotalGasUsed</param>
+    /// <returns>Returns the total amount of gas used daily for transactions on the BNB Smart Chain network.</returns>
+    Task<BnbSmartChainDailyTotalGasUsed?> GetBnbSmartChainDailyTotalGasUsed(BnbSmartChainDailyTotalGasUsedRequest request);
 }

--- a/src/BscScan.NetCore/Models/Request/GasTracker/BnbSmartChainDailyTotalGasUsedRequest.cs
+++ b/src/BscScan.NetCore/Models/Request/GasTracker/BnbSmartChainDailyTotalGasUsedRequest.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BscScan.NetCore.Models.Request.GasTracker;
+
+/// <summary>
+/// BnbSmartChainDailyTotalGasUsed
+/// </summary>
+public class BnbSmartChainDailyTotalGasUsedRequest
+{
+    /// <summary>
+    /// the starting date in yyyy-MM-dd format, eg. 2021-08-01
+    /// </summary>
+    [JsonIgnore]
+    public DateOnly StartDate { get; set; }
+
+    /// <summary>
+    /// the ending date in yyyy-MM-dd format, eg. 2021-08-28
+    /// </summary>
+    [JsonIgnore]
+    public DateOnly EndDate { get; set; }
+
+    /// <summary>
+    /// the sorting preference, use asc to sort by ascending and desc to sort by descending (default is asc)
+    /// </summary>
+    [JsonIgnore]
+    public Sort Sort { get; set; } = Sort.Asc;
+
+    /// <summary>
+    /// the starting date in yyyy-MM-dd format, eg. 2021-08-01
+    /// </summary>
+    [JsonPropertyName("startdate")]
+    public string? StartDateParam => StartDate.ToString("yyyy-MM-dd");
+
+    /// <summary>
+    /// the ending date in yyyy-MM-dd format, eg. 2021-08-28
+    /// </summary>
+    [JsonPropertyName("enddate")]
+    public string? EndDateParam => EndDate.ToString("yyyy-MM-dd");
+
+    /// <summary>
+    /// the sorting preference, use asc to sort by ascending and desc to sort by descending (default is asc)
+    /// </summary>
+
+    [JsonPropertyName("sort")]
+    public string SortParam => Sort.ToString().ToLower();
+}

--- a/src/BscScan.NetCore/Models/Response/GasTracker/BnbSmartChainDailyTotalGasUsed.cs
+++ b/src/BscScan.NetCore/Models/Response/GasTracker/BnbSmartChainDailyTotalGasUsed.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BscScan.NetCore.Models.Response.GasTracker;
+
+/// <summary>
+/// BnbSmartChainDailyTotalGasUsed
+/// </summary>
+public class BnbSmartChainDailyTotalGasUsed : BaseResponse
+{
+    /// <summary>
+    /// List of BnbSmartChainDailyTotalGasUsedData
+    /// </summary>
+    [JsonPropertyName("result")]
+    public IEnumerable<BnbSmartChainDailyTotalGasUsedData>? Result { get; set; }
+}
+
+/// <summary>
+/// BnbSmartChainDailyTotalGasUsedData
+/// </summary>
+public class BnbSmartChainDailyTotalGasUsedData
+{
+    /// <summary>
+    /// UTCDate
+    /// </summary>
+    [JsonPropertyName("UTCDate")]
+    public string? UtcDate { get; set; }
+
+    /// <summary>
+    /// unixTimeStamp
+    /// </summary>
+    [JsonPropertyName("unixTimeStamp")]
+    public string? UnixTimeStamp { get; set; }
+
+    /// <summary>
+    /// gasLimit
+    /// </summary>
+    [JsonPropertyName("gasUsed")]
+    public string? GasUsed { get; set; }
+}

--- a/src/BscScan.NetCore/Services/BscScanGasTrackerService.cs
+++ b/src/BscScan.NetCore/Services/BscScanGasTrackerService.cs
@@ -47,4 +47,17 @@ public class BscScanGasTrackerService : BaseHttpClient, IBscScanGasTrackerServic
         var result = await JsonSerializer.DeserializeAsync<DailyAverageGasLimit>(responseStream);
         return result;
     }
+
+    /// <inheritdoc />
+    public async Task<BnbSmartChainDailyTotalGasUsed?> GetBnbSmartChainDailyTotalGasUsed(BnbSmartChainDailyTotalGasUsedRequest request)
+    {
+        var queryParameters = $"{_bscScanStatsModule}{request.ToRequestParameters(GasTrackerModuleAction.DAILY_GAS_USED)}";
+        using var response = await BscScanHttpClient.GetAsync($"{queryParameters}")
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        await using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var result = await JsonSerializer.DeserializeAsync<BnbSmartChainDailyTotalGasUsed>(responseStream);
+        return result;
+    }
 }


### PR DESCRIPTION
Returns the total amount of gas used daily for transctions on the BNB Smart Chain network.