### PR TITLE
Add Get Daily New Address Count

### DIFF
--- a/src/BscScan.NetCore/Constants/Constants.cs
+++ b/src/BscScan.NetCore/Constants/Constants.cs
@@ -119,6 +119,7 @@ internal static class GasStatsModuleAction
     public const string BNB_PRICE = "bnbprice";
     public const string BNB_DAILY_PRICE = "bnbdailyprice";
     public const string DAILY_TXN_FEE = "dailytxnfee";
+    public const string DAILY_NEW_ADDRESS = "dailynewaddress";
 }
 
 /// <summary>

--- a/src/BscScan.NetCore/Contracts/IBscScanStatsService.cs
+++ b/src/BscScan.NetCore/Contracts/IBscScanStatsService.cs
@@ -39,4 +39,11 @@ public interface IBscScanStatsService
     /// <param name="request">DailyNetworkTransactionFeeRequest</param>
     /// <returns>Returns the historical amount of transaction fees paid to validators per day.</returns>
     Task<DailyNetworkTransactionFee?> GetDailyNetworkTransactionFee(DailyNetworkTransactionFeeRequest request);
+
+    /// <summary>
+    /// Get Daily New Address Count 🅰🅿🅸  🅿🆁🅾
+    /// </summary>
+    /// <param name="request">DailyNewAddressCountRequest</param>
+    /// <returns>Returns the historical number of new BNB Smart Chain addresses created per day.</returns>
+    Task<DailyNewAddressCount?> GetDailyNewAddressCount(DailyNewAddressCountRequest request);
 }

--- a/src/BscScan.NetCore/Models/Request/Stats/DailyNewAddressCountRequest.cs
+++ b/src/BscScan.NetCore/Models/Request/Stats/DailyNewAddressCountRequest.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BscScan.NetCore.Models.Request.Stats;
+
+/// <summary>
+/// DailyNewAddressCountRequest
+/// </summary>
+public class DailyNewAddressCountRequest
+{
+    /// <summary>
+    /// the starting date in yyyy-MM-dd format, eg. 2020-10-01
+    /// </summary>
+    [JsonIgnore]
+    public DateOnly StartDate { get; set; }
+
+    /// <summary>
+    /// the ending date in yyyy-MM-dd format, eg. 2020-10-31
+    /// </summary>
+    [JsonIgnore]
+    public DateOnly EndDate { get; set; }
+
+    /// <summary>
+    /// the sorting preference, use asc to sort by ascending and desc to sort by descending (default is asc)
+    /// </summary>
+    [JsonIgnore]
+    public Sort Sort { get; set; } = Sort.Asc;
+
+    /// <summary>
+    /// the starting date in yyyy-MM-dd format, eg. 2020-10-01
+    /// </summary>
+    [JsonPropertyName("startdate")]
+    public string? StartDateParam => StartDate.ToString("yyyy-MM-dd");
+
+    /// <summary>
+    /// the ending date in yyyy-MM-dd format, eg. 2020-10-31
+    /// </summary>
+    [JsonPropertyName("enddate")]
+    public string? EndDateParam => EndDate.ToString("yyyy-MM-dd");
+
+    /// <summary>
+    /// the sorting preference, use asc to sort by ascending and desc to sort by descending (default is asc)
+    /// </summary>
+
+    [JsonPropertyName("sort")]
+    public string SortParam => Sort.ToString().ToLower();
+}

--- a/src/BscScan.NetCore/Models/Response/Stats/DailyNewAddressCount.cs
+++ b/src/BscScan.NetCore/Models/Response/Stats/DailyNewAddressCount.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BscScan.NetCore.Models.Response.Stats;
+
+/// <summary>
+/// 
+/// </summary>
+public class DailyNewAddressCount :BaseResponse
+{
+    /// <summary>
+    /// List of DailyNetworkTransactionFeeData
+    /// </summary>
+    [JsonPropertyName("result")]
+    public IEnumerable<DailyNewAddressCountData>? Result { get; set; }
+}
+
+/// <summary>
+/// DailyNewAddressCountData
+/// </summary>
+public class DailyNewAddressCountData
+{
+    /// <summary>
+    /// UTCDate
+    /// </summary>
+    [JsonPropertyName("UTCDate")]
+    public string? UtcDate { get; set; }
+
+    /// <summary>
+    /// unixTimeStamp
+    /// </summary>
+    [JsonPropertyName("unixTimeStamp")]
+    public string? UnixTimeStamp { get; set; }
+
+    /// <summary>
+    /// newAddressCount
+    /// </summary>
+    [JsonPropertyName("newAddressCount")]
+    public string? NewAddressCount { get; set; }
+}

--- a/src/BscScan.NetCore/Services/BscScanStatsService.cs
+++ b/src/BscScan.NetCore/Services/BscScanStatsService.cs
@@ -84,4 +84,17 @@ public class BscScanStatsService : BaseHttpClient, IBscScanStatsService
         var result = await JsonSerializer.DeserializeAsync<DailyNetworkTransactionFee>(responseStream);
         return result;
     }
+
+    /// <inheritdoc />
+    public async Task<DailyNewAddressCount?> GetDailyNewAddressCount(DailyNewAddressCountRequest request)
+    {
+        var queryParameters = $"{_bscScanStatsModule}{request.ToRequestParameters(GasStatsModuleAction.DAILY_NEW_ADDRESS)}";
+        using var response = await BscScanHttpClient.GetAsync($"{queryParameters}")
+            .ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        await using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var result = await JsonSerializer.DeserializeAsync<DailyNewAddressCount>(responseStream);
+        return result;
+    }
 }


### PR DESCRIPTION
Returns the historical number of new BNB Smart Chain addresses created per day.